### PR TITLE
商品表示変更、ログイン分岐

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,5 @@
 class ProductsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index,:show]
 
   def index 
     @products = Product.all.order(created_at: :desc)
@@ -19,6 +19,7 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
   end
 
   def edit
@@ -29,4 +30,6 @@ class ProductsController < ApplicationController
   def product_params
     params.require(:product).permit(:name, :description, :image,:category_id ,:condition_id,:shippingfee_id,:prefecture_id,:scheduleddelivery_id,:price).merge(user_id: current_user.id,)
   end
+ 
+
 end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,8 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-     <% @products.each do |product| %>
+    <% @products.each do |product| %>
       <li class='list'>
         <%= link_to product_path(product.id) do %>
         <div class='item-img-content'>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -131,7 +131,7 @@
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
      <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to product_path(product.id) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" if product.image.attached? %>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -25,7 +25,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
      <% if user_signed_in? && current_user.id == @product.user_id %>
      
     <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
@@ -84,7 +83,7 @@
   </div>
 
   <% end %>
-  <%# /商品の概要 %>
+  
 
   <div class="comment-box">
     <form>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -41,7 +41,7 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
    
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -108,9 +108,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -5,10 +5,10 @@
   <div class="item-box">
   
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag ("item-sample.png" ,onerror: "this.onerror=null; this.src='app/assets/images/item_sample.png';") %>class:"item-box-img" %>
+      <%= image_tag @product.image, class:"item-box-img" %>
       
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
@@ -18,26 +18,26 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+          ¥<%= @product.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @product.shippingfee.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-     <%# if user_signed_in? && current_user.id == product.user_id %>
+     <% if user_signed_in? && current_user.id == @product.user_id %>
      
     <%= link_to "商品の編集", "#" , method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <%# end%>
+    <%  else %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
+    
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
    
     <div class="item-explain-box">
@@ -47,27 +47,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name%></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%=@product.condition.condition  %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shippingfee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.scheduleddelivery.name %></td>
         </tr>
       </tbody>
     </table>
@@ -82,6 +82,8 @@
       </div>
     </div>
   </div>
+
+  <% end %>
   <%# /商品の概要 %>
 
   <div class="comment-box">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   # root "articles#index"
   root to: "products#index"
 
-  resources :products, only: [:index, :new, :create,:show,:edit]
+  resources :products, only: [:index, :new, :create, :show, :edit]
 end


### PR DESCRIPTION
#why
商品詳細表示機能


#what
商品詳細表示ページは、ログイン状況や商品の販売状況に関係なく、誰でも見ることができること。
 商品一覧ページにて商品情報をクリックすると、該当する商品の商品詳細表示ページへ遷移すること。
 商品出品時に登録した情報（商品名・商品画像・価格・配送料の負担・商品の説明・出品者名・カテゴリー・商品の状態・発送元の地域・発送日の目安）が、見本アプリと同様の形で表示されること。
 画像が表示されており、画像がリンク切れなどにならないこと。
 ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示されること。
 ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示されること。
ログアウト状態の場合は、商品の販売状況に関わらず、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。