### PR TITLE
削除の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index,:show]
   before_action :set_product, only: [:show, :edit, :update, :move_to_index, :destroy]
-  before_action :require_same_user, only: [:edit, :move_to_index,:destroy]
+  before_action :require_same_user, only: [:edit, :destroy]
 
 
   def index 
@@ -36,8 +36,7 @@ class ProductsController < ApplicationController
     end
   end
   
-  def move_to_index
-  end
+  
 
   def destroy
     if @product.destroy

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index,:show]
-  before_action :set_product, only: [:show, :edit, :update, :move_to_index]
-  before_action :require_same_user, only: [:edit, :move_to_index]
+  before_action :set_product, only: [:show, :edit, :update, :move_to_index, :destroy]
+  before_action :require_same_user, only: [:edit, :move_to_index,:destroy]
 
 
   def index 
@@ -37,6 +37,14 @@ class ProductsController < ApplicationController
   end
   
   def move_to_index
+  end
+
+  def destroy
+    if @product.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
   end
 
   private

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -29,7 +29,7 @@
      
     <%= link_to "商品の編集", edit_product_path , method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", product_path, data: {turbo_method: :delete}, class:"item-destroy" %>
     <%  else %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   # root "articles#index"
   root to: "products#index"
 
-  resources :products, only: [:index, :new, :create, :show, :edit,:update]
+  resources :products, only: [:index, :new, :create, :show, :edit,:update, :destroy]
 end


### PR DESCRIPTION
#why 商品の削除の実装

#what
 ログイン状態の場合にのみ、自身が出品した商品情報を削除できること。
 削除が完了したら、トップページに遷移すること。

https://gyazo.com/63217f954aed06606e031f6422c743e7
削除後のトップページ
https://gyazo.com/59f80b87f6a7a1aee7a5ab87a3f93371